### PR TITLE
ASTRACTL-28426 Change Restic --no-lock logic to allow flag without --dry-run

### DIFF
--- a/cmd/restic/cmd_forget.go
+++ b/cmd/restic/cmd_forget.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"io"
 
-	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/restic"
 	"github.com/spf13/cobra"
 )
@@ -113,10 +112,11 @@ func runForget(ctx context.Context, opts ForgetOptions, gopts GlobalOptions, arg
 	if err != nil {
 		return err
 	}
-
+	/* NetApp Change.  Continue with --no-lock
 	if gopts.NoLock && !opts.DryRun {
 		return errors.Fatal("--no-lock is only applicable in combination with --dry-run for forget command")
 	}
+	*/
 
 	if !opts.DryRun || !gopts.NoLock {
 		var lock *restic.Lock

--- a/cmd/restic/lock.go
+++ b/cmd/restic/lock.go
@@ -42,8 +42,11 @@ func lockRepository(ctx context.Context, repo restic.Repository, exclusive bool)
 	if exclusive {
 		lockFn = restic.NewExclusiveLock
 	}
-
-	lock, err := lockFn(ctx, repo)
+	noLock := false
+	if globalOptions.NoLock {
+		noLock = true
+	}
+	lock, err := lockFn(ctx, repo, noLock)
 	if restic.IsInvalidLock(err) {
 		return nil, ctx, errors.Fatalf("%v\n\nthe `unlock --remove-all` command can be used to remove invalid locks. Make sure that no other restic process is accessing the repository when running the command", err)
 	}

--- a/internal/restic/lock_test.go
+++ b/internal/restic/lock_test.go
@@ -17,7 +17,7 @@ import (
 func TestLock(t *testing.T) {
 	repo := repository.TestRepository(t)
 
-	lock, err := restic.NewLock(context.TODO(), repo)
+	lock, err := restic.NewLock(context.TODO(), repo, false)
 	rtest.OK(t, err)
 
 	rtest.OK(t, lock.Unlock())
@@ -26,7 +26,7 @@ func TestLock(t *testing.T) {
 func TestDoubleUnlock(t *testing.T) {
 	repo := repository.TestRepository(t)
 
-	lock, err := restic.NewLock(context.TODO(), repo)
+	lock, err := restic.NewLock(context.TODO(), repo, false)
 	rtest.OK(t, err)
 
 	rtest.OK(t, lock.Unlock())
@@ -39,10 +39,10 @@ func TestDoubleUnlock(t *testing.T) {
 func TestMultipleLock(t *testing.T) {
 	repo := repository.TestRepository(t)
 
-	lock1, err := restic.NewLock(context.TODO(), repo)
+	lock1, err := restic.NewLock(context.TODO(), repo, false)
 	rtest.OK(t, err)
 
-	lock2, err := restic.NewLock(context.TODO(), repo)
+	lock2, err := restic.NewLock(context.TODO(), repo, false)
 	rtest.OK(t, err)
 
 	rtest.OK(t, lock1.Unlock())
@@ -64,10 +64,10 @@ func TestMultipleLockFailure(t *testing.T) {
 	be := &failLockLoadingBackend{Backend: mem.New()}
 	repo := repository.TestRepositoryWithBackend(t, be, 0)
 
-	lock1, err := restic.NewLock(context.TODO(), repo)
+	lock1, err := restic.NewLock(context.TODO(), repo, false)
 	rtest.OK(t, err)
 
-	_, err = restic.NewLock(context.TODO(), repo)
+	_, err = restic.NewLock(context.TODO(), repo, false)
 	rtest.Assert(t, err != nil, "unreadable lock file did not result in an error")
 
 	rtest.OK(t, lock1.Unlock())
@@ -76,7 +76,7 @@ func TestMultipleLockFailure(t *testing.T) {
 func TestLockExclusive(t *testing.T) {
 	repo := repository.TestRepository(t)
 
-	elock, err := restic.NewExclusiveLock(context.TODO(), repo)
+	elock, err := restic.NewExclusiveLock(context.TODO(), repo, false)
 	rtest.OK(t, err)
 	rtest.OK(t, elock.Unlock())
 }
@@ -84,10 +84,10 @@ func TestLockExclusive(t *testing.T) {
 func TestLockOnExclusiveLockedRepo(t *testing.T) {
 	repo := repository.TestRepository(t)
 
-	elock, err := restic.NewExclusiveLock(context.TODO(), repo)
+	elock, err := restic.NewExclusiveLock(context.TODO(), repo, false)
 	rtest.OK(t, err)
 
-	lock, err := restic.NewLock(context.TODO(), repo)
+	lock, err := restic.NewLock(context.TODO(), repo, false)
 	rtest.Assert(t, err != nil,
 		"create normal lock with exclusively locked repo didn't return an error")
 	rtest.Assert(t, restic.IsAlreadyLocked(err),
@@ -100,10 +100,10 @@ func TestLockOnExclusiveLockedRepo(t *testing.T) {
 func TestExclusiveLockOnLockedRepo(t *testing.T) {
 	repo := repository.TestRepository(t)
 
-	elock, err := restic.NewLock(context.TODO(), repo)
+	elock, err := restic.NewLock(context.TODO(), repo, false)
 	rtest.OK(t, err)
 
-	lock, err := restic.NewExclusiveLock(context.TODO(), repo)
+	lock, err := restic.NewExclusiveLock(context.TODO(), repo, false)
 	rtest.Assert(t, err != nil,
 		"create normal lock with exclusively locked repo didn't return an error")
 	rtest.Assert(t, restic.IsAlreadyLocked(err),
@@ -250,7 +250,7 @@ func TestRemoveAllLocks(t *testing.T) {
 func TestLockRefresh(t *testing.T) {
 	repo := repository.TestRepository(t)
 
-	lock, err := restic.NewLock(context.TODO(), repo)
+	lock, err := restic.NewLock(context.TODO(), repo, false)
 	rtest.OK(t, err)
 	time0 := lock.Time
 


### PR DESCRIPTION
For immutable storage backup, the lock file cannot be removed during the normal Restic operation (backup, snapshots, forget).   In order to support immutable storage to against ransomware, we need to to fully support --no-lock option for Restic command line.   At this moment, restic only support --no-lock option in forget command with --dry-run option together.

We understand that without lock file, it is dangerous to run restic.   But from our investigation, it may be safe in our backup scenario.