### PR TITLE
ASTRACTL-29934 / CRITICAL BUG FIX - Immutable Backups - Skip Lock Refresh when --no-lock used

### DIFF
--- a/cmd/restic/lock.go
+++ b/cmd/restic/lock.go
@@ -103,17 +103,26 @@ func refreshLocks(ctx context.Context, lock *restic.Lock, lockInfo *lockContext,
 			debug.Log("terminate")
 			return
 		case <-ticker.C:
-			if time.Since(lastRefresh) > refreshabilityTimeout || globalOptions.NoLock {
+			if time.Since(lastRefresh) > refreshabilityTimeout {
 				// the lock is too old, wait until the expiry monitor cancels the context
 				continue
 			}
 
 			debug.Log("refreshing locks")
-			err := lock.Refresh(context.TODO())
-			if err != nil {
-				Warnf("unable to refresh lock: %v\n", err)
-			} else {
-				lastRefresh = lock.Time
+			var err error = nil
+			if !globalOptions.NoLock {
+				err := lock.Refresh(context.TODO())
+				if err != nil {
+					Warnf("unable to refresh lock: %v\n", err)
+				}
+			}
+
+			if err == nil {
+				if globalOptions.NoLock {
+					lastRefresh = time.Now()
+				} else {
+					lastRefresh = lock.Time
+				}
 				// inform monitor gorountine about successful refresh
 				select {
 				case <-ctx.Done():

--- a/cmd/restic/lock.go
+++ b/cmd/restic/lock.go
@@ -111,7 +111,7 @@ func refreshLocks(ctx context.Context, lock *restic.Lock, lockInfo *lockContext,
 			debug.Log("refreshing locks")
 			var err error = nil
 			if !globalOptions.NoLock {
-				err := lock.Refresh(context.TODO())
+				err = lock.Refresh(context.TODO())
 				if err != nil {
 					Warnf("unable to refresh lock: %v\n", err)
 				}

--- a/cmd/restic/lock.go
+++ b/cmd/restic/lock.go
@@ -103,7 +103,7 @@ func refreshLocks(ctx context.Context, lock *restic.Lock, lockInfo *lockContext,
 			debug.Log("terminate")
 			return
 		case <-ticker.C:
-			if time.Since(lastRefresh) > refreshabilityTimeout {
+			if time.Since(lastRefresh) > refreshabilityTimeout || globalOptions.NoLock {
 				// the lock is too old, wait until the expiry monitor cancels the context
 				continue
 			}


### PR DESCRIPTION
### PROBLEM / SOLUTION
When enough time passes (usually triggered by applications with a lot of data -> long backup) in a backup, a lock will be refreshed. Normally, this would be fine. However, when --no-lock is used, for example, with immutable backups, the refreshLock code still kicks off after a certain amount of time, usually 5 minutes. When that happens, a lock is created (createLock executes). We don't want this to happen, as when we use --no-lock, we mean it. No locks should appear for any reason, at any time.

However, restic is stubborn. We can't simply skip the lock refresh logic and be done there. We need to trick restic into thinking the lock refresh process is happening and going smoothly, as there are processes/monitors in place to make sure of this (if anything goes wrong, the backup/context is killed).  You'll see some logic where I set the refreshTime to time.Now() in the case of --no-lock for this reason. I am tricking restic into thinking everything is fine.

### ISSUE

ASTRACTL-29934(https://jira.ngage.netapp.com/browse/ASTRACTL-29934)


### NOTE
Since we do not use --no-lock anywhere else except with immutable backups, this code change should completely leave all restic functionality used by Astra elsewhere unaffected.

### TESTING
1. All unit tests pass
2. Previous test cases that were failing (Any large file that back's up for 5+ minutes) pass.
    i. 2GB file backup passes
    ii. 25GB file backup passes (previously failed on @patric0303's system with ANF backend)

